### PR TITLE
Pull out failure handling logic in to pool handler abstraction

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,39 +1,40 @@
 var EndpointPool,
-    _      = require('underscore'),
-    dns    = require('dns'),
-    Events = require('events'),
-    util   = require('util'),
+    _           = require('underscore'),
+    dns         = require('dns'),
+    Events      = require('events'),
+    PoolManager = require('./pool-manager'),
+    util        = require('util'),
 
-    DNS_LOOKUP_TIMEOUT = 1000,
-
-    CLOSED            = 0,  // closed circuit: endpoint is good to use
-    HALF_OPEN_READY   = 1,  // endpoint is in recovery state: offer it for use once
-    HALF_OPEN_PENDING = 2,  // endpoint recovery is in process
-    OPEN              = 3;  // open circuit: endpoint is no good
+    DNS_LOOKUP_TIMEOUT = 1000;
 
 /**
- * @param {String}   discoveryName The name of the service discovery host
- * @param {Number}   ttl           How long the endpoints are valid for. The service discovery endpoint will be checked on
- *                                 this interval.
- * @param {Number}   maxFailures   Number of failures allowed before the endpoint circuit breaker is tripped.
- * @param {Number}   failureWindow Size of the sliding window of time in which the failures are counted.
- * @param {Number}   resetTimeout  Amount of time before putting the circuit back into half open state.
- * @param {Function} onReady       Callback to execute when endpoints have been primed (updated for the first time)
+ * @param {String}    discoveryName       The name of the service discovery host
+ * @param {Number}    ttl                 How long the endpoints are valid for. The service discovery endpoint will be checked on
+ *                                        this interval.
+ * @param {{maxFailures: Number, failureWindow: Number, resetTimeout: Number}}
+ *                    ejectOnErrorConfig  How to handle endpoint errors. If specified, the following options must be defined:
+ *                                        - maxFailures: Number of failures allowed before the endpoint circuit breaker is tripped.
+ *                                        - failureWindow: Size of the sliding window of time in which the failures are counted.
+ *                                        - resetTimeout: Amount of time before putting the circuit back into half open state.
+ * @param {Function=} onReady       Callback to execute when endpoints have been primed (updated for the first time)
  */
-module.exports = EndpointPool = function (discoveryName, ttl, maxFailures, failureWindow, resetTimeout, onReady) {
-  if (!discoveryName || !ttl || !maxFailures || !resetTimeout) {
+module.exports = EndpointPool = function (discoveryName, ttl, ejectOnErrorConfig, onReady) {
+  if (!discoveryName || !ttl) {
     throw new Error('Must supply all arguments');
   }
+
+  if (ejectOnErrorConfig) {
+    this.poolManager = PoolManager.ejectOnErrorPoolManager(ejectOnErrorConfig);
+  } else {
+    this.poolManager = PoolManager.defaultPoolManager();
+  }
+
   Events.EventEmitter.call(this);
 
   this.discoveryName = discoveryName;
   this.ttl = ttl;
-  this.endpoints = [];
-  this._endpointOffset = 0;
   this._updateTimeout = null;
-  this.maxFailures = maxFailures;
-  this.failureWindow = failureWindow;
-  this.resetTimeout = resetTimeout;
+
   this.lastUpdate = Date.now();
   this.update(onReady);
 };
@@ -64,96 +65,21 @@ _.extend(EndpointPool.prototype, {
   },
 
   getEndpoint: function () {
-    var endpoint, i, l, offset;
-    for (i = 0, l = this.endpoints.length; i < l; ++i) {
-      offset = (this._endpointOffset + i) % l;
-      endpoint = this.endpoints[offset];
+    var endpoint = this.poolManager.getNextEndpoint();
 
-      switch (endpoint.state) {
-        case HALF_OPEN_READY:
-          endpoint.state = HALF_OPEN_PENDING; // let one through, then turn it off again
-          /* falls through */
-        case CLOSED:
-          this._endpointOffset = offset + 1;
-          return endpoint;
-        // case OPEN: case HALF_OPEN_PENDING: // continue to the next one
-      }
+    if (endpoint) {
+      return endpoint;
+    } else {
+      this.emit('noEndpoints');
+      return null;
     }
-    this.emit('noEndpoints');
-    return null;
   },
 
   setEndpoints: function (endpoints) {
-    var newEndpoints, i, matchingEndpoint;
-
-    newEndpoints = endpoints.map(function (info) {
-      return new Endpoint(info, this.maxFailures, this.failureWindow, this.resetTimeout);
-    }, this);
-
-    for (i = this.endpoints.length; i--;) {
-      matchingEndpoint = _.findWhere(newEndpoints, { url: this.endpoints[i].url });
-
-      if (matchingEndpoint) { // found a match, remove it from `newEndpoints`, since it's not new
-        newEndpoints = _.without(newEndpoints, matchingEndpoint);
-      } else { // didn't find a match in endpoints, so kill that endpoint
-        this.endpoints.splice(i, 1);
-      }
-    }
-    // push all the actually-new endpoints in
-    this.endpoints.push.apply(this.endpoints, newEndpoints);
+    this.poolManager.updateEndpoints(endpoints);
   },
 
   stopUpdating: function () {
     clearTimeout(this._updateTimeout);
   }
 });
-
-function Endpoint(info, maxFailures, failureWindow, resetTimeout) {
-  this.name = info.name;
-  this.port = info.port;
-  this.url = info.name + ':' + info.port;
-  this.state = CLOSED;
-  this.failCount = 0;
-  this.callback = endpointCallback.bind(this);
-  this.disable = disableEndpoint.bind(this);
-  this.resetTimeout = resetTimeout;
-  this.failureWindow = failureWindow;
-  // A ring buffer, holding the timestamp of each error. As we loop around the ring, the timestamp in the slot we're
-  // about to fill will tell us the error rate. That is, `maxFailure` number of requests in how many milliseconds?
-  this.buffer = new Array(maxFailures - 1);
-  this.bufferPointer = 0;
-}
-
-function endpointCallback(err) {
-  if (err) {
-    var oldestErrorTime, now;
-    if (this.state === OPEN) {
-      return;
-    }
-
-    if (this.buffer.length === 0) {
-      this.disable();
-      return;
-    }
-
-    oldestErrorTime = this.buffer[this.bufferPointer];
-    now = Date.now();
-    this.buffer[this.bufferPointer] = now;
-    this.bufferPointer++;
-    this.bufferPointer %= this.buffer.length;
-
-    if (this.state === HALF_OPEN_PENDING || (oldestErrorTime != null && now - oldestErrorTime <= this.failureWindow)) {
-      this.disable();
-    }
-  } else if (this.state === HALF_OPEN_PENDING) {
-    this.state = CLOSED;
-  }
-}
-
-function disableEndpoint() {
-  this.state = OPEN;
-  clearInterval(this._reopenTimeout);
-  this._reopenTimeout = setTimeout(function () {
-    this.state = HALF_OPEN_READY;
-  }.bind(this), this.resetTimeout);
-}

--- a/pool-manager.js
+++ b/pool-manager.js
@@ -1,0 +1,132 @@
+var _ = require('underscore');
+
+function PoolManager (options) {
+  options = options || {};
+
+  this.endpoints = [];
+  this._endpointOffset = 0;
+
+  this.isInPool = options.isInPool || _.constant(true);
+  this.onEndpointReturned = options.onEndpointReturned || _.noop;
+  this.onEndpointRegistered = options.onEndpointRegistered || _.noop;
+}
+
+PoolManager.prototype = {
+  getNextEndpoint: function () {
+    var i, l, offset, endpoint;
+
+    for (i = 0, l = this.endpoints.length; i < l; ++i) {
+      offset = (this._endpointOffset + i) % l;
+      endpoint = this.endpoints[offset];
+
+      if (this.isInPool(endpoint)) {
+        this._endpointOffset = offset + 1;
+        return endpoint;
+      }
+    }
+  },
+  updateEndpoints: function (endpoints) {
+    newEndpoints = endpoints.map(function (info) {
+      return new Endpoint(info);
+    });
+
+    for (i = this.endpoints.length; i--;) {
+      matchingEndpoint = _.findWhere(newEndpoints, { url: this.endpoints[i].url });
+
+      if (matchingEndpoint) { // found a match, remove it from `newEndpoints`, since it's not new
+        newEndpoints = _.without(newEndpoints, matchingEndpoint);
+      } else { // didn't find a match in endpoints, so kill that endpoint
+        this.endpoints.splice(i, 1);
+      }
+    }
+
+    newEndpoints.forEach(function (endpoint) {
+      endpoint.callback = this.onEndpointReturned.bind(this, endpoint);
+      this.onEndpointRegistered(endpoint);
+    }, this);
+    // push all the actually-new endpoints in
+    this.endpoints.push.apply(this.endpoints, newEndpoints);
+  }
+};
+
+function Endpoint(info) {
+  this.name = info.name;
+  this.port = info.port;
+  this.url = info.name + ':' + info.port;
+}
+
+module.exports = {
+  defaultPoolManager: function () {
+    return new PoolManager();
+  },
+  ejectOnErrorPoolManager: function (options) {
+    // endpoint states
+    var CLOSED            = 0,  // closed circuit: endpoint is good to use
+        HALF_OPEN_READY   = 1,  // endpoint is in recovery state: offer it for use once
+        HALF_OPEN_PENDING = 2,  // endpoint recovery is in process
+        OPEN              = 3;  // open circuit: endpoint is no good
+
+    if (!options || !(options.failureWindow && options.maxFailures && options.resetTimeout)) {
+      throw new Error('Must supply all arguments to ejectOnErrorPoolManager');
+    }
+
+    var failureWindow = options.failureWindow;
+    var maxFailures = options.maxFailures;
+    var resetTimeout = options.resetTimeout;
+
+    function disableEndpoint(endpoint) {
+      endpoint.state = OPEN;
+      clearInterval(endpoint._reopenTimeout);
+      endpoint._reopenTimeout = setTimeout(function () {
+        endpoint.state = HALF_OPEN_READY;
+      }, resetTimeout);
+    }
+
+    return new PoolManager({
+      isInPool: function (endpoint) {
+        switch (endpoint.state) {
+          case HALF_OPEN_READY:
+            endpoint.state = HALF_OPEN_PENDING; // let one through, then turn it off again
+            /* falls through */
+          case CLOSED:
+            return true;
+          default:
+            return false;
+        }
+      },
+      onEndpointRegistered: function (endpoint) {
+        endpoint.state = CLOSED;
+        endpoint.failCount = 0;
+        // A ring buffer, holding the timestamp of each error. As we loop around the ring, the timestamp in the slot we're
+        // about to fill will tell us the error rate. That is, `maxFailure` number of requests in how many milliseconds?
+        endpoint.buffer = new Array(maxFailures - 1);
+        endpoint.bufferPointer = 0;
+      },
+      onEndpointReturned: function (endpoint, err) {
+        if (err) {
+          var oldestErrorTime, now;
+          if (endpoint.state === OPEN) {
+            return;
+          }
+
+          if (endpoint.buffer.length === 0) {
+            disableEndpoint(endpoint);
+            return;
+          }
+
+          oldestErrorTime = endpoint.buffer[endpoint.bufferPointer];
+          now = Date.now();
+          endpoint.buffer[endpoint.bufferPointer] = now;
+          endpoint.bufferPointer++;
+          endpoint.bufferPointer %= endpoint.buffer.length;
+
+          if (endpoint.state === HALF_OPEN_PENDING || (oldestErrorTime != null && now - oldestErrorTime <= failureWindow)) {
+            disableEndpoint(endpoint);
+          }
+        } else if (endpoint.state === HALF_OPEN_PENDING) {
+          endpoint.state = CLOSED;
+        }
+      }
+    })
+  }
+};


### PR DESCRIPTION
This helps use this library in two separate use-cases:

- You have a pool of endpoints that it's safe to assume will be
  healthy (something else is removing failing/bad hosts for you)
- You want to be the decision-maker on whether an endpoint is
  healthy or not (by manually calling a `callback` on the endpoint
  when it returns.)

Also, it could allow us to introduce another type of pool management
down the road (polling a health check endpoint as opposed to examining
every endpoint's response codes, for example.)